### PR TITLE
Add support to existing connection

### DIFF
--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -89,7 +89,10 @@ export function getModelForClass<U extends AnyParamConstructor<any>, QueryHelper
     compiledmodel.syncIndexes();
   }
 
-  return addModelToTypegoose<U, QueryHelpers>(compiledmodel, cl);
+  return addModelToTypegoose<U, QueryHelpers>(compiledmodel, cl, {
+    existingMongoose: roptions?.existingMongoose,
+    existingConnection: roptions?.existingConnection
+  });
 }
 
 /**
@@ -147,6 +150,7 @@ export function buildSchema<U extends AnyParamConstructor<any>>(cl: U, options?:
  * Note: no gurantee that the type information is fully correct
  * @param model The model to store
  * @param cl The Class to store
+ * @param options? Optional param for existingMongoose or existingConnection
  * @example
  * ```ts
  * class Name {}
@@ -156,8 +160,14 @@ export function buildSchema<U extends AnyParamConstructor<any>>(cl: U, options?:
  * const model = addModelToTypegoose(mongoose.model("Name", schema), Name);
  * ```
  */
-export function addModelToTypegoose<U extends AnyParamConstructor<any>, QueryHelpers = {}>(model: mongoose.Model<any>, cl: U) {
-  assertion(model.prototype instanceof mongoose.Model, new TypeError(`"${model}" is not a valid Model!`));
+export function addModelToTypegoose<U extends AnyParamConstructor<any>, QueryHelpers = {}>(
+  model: mongoose.Model<any>,
+  cl: U,
+  options?: { existingMongoose?: mongoose.Mongoose; existingConnection: any }
+) {
+  const mongooseModel = options?.existingMongoose?.Model || options?.existingConnection?.base.Model || mongoose.Model;
+
+  assertion(model.prototype instanceof mongooseModel, new TypeError(`"${model}" is not a valid Model!`));
   assertionIsClass(cl);
 
   const name = getName(cl);

--- a/src/typegoose.ts
+++ b/src/typegoose.ts
@@ -165,7 +165,7 @@ export function addModelToTypegoose<U extends AnyParamConstructor<any>, QueryHel
   cl: U,
   options?: { existingMongoose?: mongoose.Mongoose; existingConnection: any }
 ) {
-  const mongooseModel = options?.existingMongoose?.Model || options?.existingConnection?.base.Model || mongoose.Model;
+  const mongooseModel = options?.existingMongoose?.Model || options?.existingConnection?.base?.Model || mongoose.Model;
 
   assertion(model.prototype instanceof mongooseModel, new TypeError(`"${model}" is not a valid Model!`));
   assertionIsClass(cl);


### PR DESCRIPTION
## Add optional param to `addModelToTypegoose` to allow assertion on compiledmodel when global mongoose is not initiated or is not the correct connection

```
export function addModelToTypegoose<U extends AnyParamConstructor<any>, QueryHelpers = {}>(
  model: mongoose.Model<any>,
  cl: U,
  options?: { existingMongoose?: mongoose.Mongoose; existingConnection: any })
```

- add param `options?` to fix an issue when using an outside module for creating the connection with mongoose
when the connection is created in another module - the assertion fails and in reality `existingConnection` and `existingMongoose` do not work.

existingConnection is of type `any` and not `mongoose.Connection` since the mongoose types definition has no `base` for it. Without `base` there was no way to get the mongoose object for assertion.